### PR TITLE
Web 24.2 | Доработки для PR #12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ SRCS		:=  main.cpp \
 					logger.cpp \
 					file.cpp \
 					debug.cpp \
-          time.cpp \
+					time.cpp \
 					string.cpp \
-				) 
+				)
 				# $(addprefix example_dir/,
 				#	 example1.cpp,
 				#	 example2.cpp

--- a/headers/config/parser/parser.hpp
+++ b/headers/config/parser/parser.hpp
@@ -17,7 +17,7 @@ namespace WS { namespace Config
 
     /* @brief Parsing and read config file.
       */
-    static void   parsFile(const char *filename, Config &out);
+    static void   parseFile(const char *filename, Config &out);
 
     /* @brief Parsing config.
       */

--- a/headers/core/core.hpp
+++ b/headers/core/core.hpp
@@ -26,8 +26,6 @@ namespace WS { namespace Core
     Server& operator=(const Server&) { return *this; }
 
   public:
-
-    static Server &  getInstance();
     
     /* @brief Server initialization.
       *  @exception std::exception  Throws when function fails 
@@ -41,13 +39,6 @@ namespace WS { namespace Core
       */
     int     run(void);
     
-    /* @brief Preparing Server before work
-      *         (set up logger, read config, add thread poll and etc.)
-      *  @exception std::exception  Throws when configuration fails 
-      *                             (check error message)
-      */    
-    void    configure(void); // ?
-
   private:
 
     /* @brief Tells if the socket is a listening socket

--- a/sources/config/parser.cpp
+++ b/sources/config/parser.cpp
@@ -103,7 +103,7 @@ namespace WS { namespace Config
     out.location_list.push_back(new_location);
   }
 
-  void              Parser::parsFile(const char *filename, Config &out) 
+  void              Parser::parseFile(const char *filename, Config &out) 
   {
     std::ifstream   conffile(filename);
     std::string     data;

--- a/sources/core/core.cpp
+++ b/sources/core/core.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <unistd.h> // only for close() [very fckng inconvenient]
+#include <errno.h>
 
 #include <stdlib.h> // remove // atoi
 
@@ -18,15 +19,14 @@ namespace WS { namespace Core
 {
   
   Server  Server::instance_;
-  Server&  Server::getInstance() { return instance_; }
 
   void  Server::init(const char* config_path)
   {
-    std::stringstream ss;
-
-    WS::Config::Parser::parsFile(config_path, const_cast<Config::Config&>(conf_));
+    // Config
+    WS::Config::Parser::parseFile(config_path, const_cast<Config::Config&>(conf_));
     WS::Utils::Debug::printConf(conf_); // < DEBUG
 
+    // Sockets
     FD_ZERO(&master_set_);
 
     listening_socket_.reserve(conf_.server_list.size());

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, const char *argv[])
   try
   {
     WS::Utils::Logger::init(WS::Utils::Logger::LOGLEV_DEBUG, true);
-    WS::Core::Server& server = WS::Core::Server::getInstance();
+    WS::Core::Server& server = WS::Core::Server::instance_;
 
     server.init(config_path);
     server.run();


### PR DESCRIPTION
* Изменил схему singleton'а (убрал лишний `getInstance`) в `Core::Server` и удалил лишний метод `configure` (заготовка с ранней версии программы)
* Изменил опечатку в `Config::Parser` (`parsFile()` -> `parseFile()`)
* Добавил хэдер `errno.h` для `errno`, так как лично у меня оно не собиралось просто так
* Чуть исправил (хотя вопрос как у кого отображается) выравнивание в `Makefile` 